### PR TITLE
bugfix: crash when no confirmed email

### DIFF
--- a/lib/omniauth/strategies/bitbucket.rb
+++ b/lib/omniauth/strategies/bitbucket.rb
@@ -30,8 +30,9 @@ module OmniAuth
       def raw_info
         @raw_info ||= begin
                         ri = MultiJson.decode(access_token.get('/api/1.0/user').body)['user']
-                        email = (MultiJson.decode(access_token.get('/api/1.0/emails').body).find { |email| email['primary'] })['email']
-                        ri.merge('email' => email) if email
+                        email = MultiJson.decode(access_token.get('/api/1.0/emails').body).find { |email| email['primary'] }
+                        ri.merge!('email' => email['email']) if email
+                        ri
                       end
       end
     end


### PR DESCRIPTION
Hi sishen

I found that when link to bitbucket account without any email confirmed, it's will crash with errors:

```
A NoMethodError occurred in #:
 undefined method `[]' for nil:NilClass
 omniauth-bitbucket (0.0.1) lib/omniauth/strategies/bitbucket.rb:33:in `raw_info'
```

The root cause is that at this case Bitbucket API will not give us emails with primary as true.

the result of emails API is:

without email confirmed:

```
"email"=>
 [{"active": false, "email": "bin@liubin.org",       "primary": false}]"}]
```

with email confirmed:

```
"email"=>
 [{"active": true,  "email": "liubin0329@gmail.com", "primary": true}]"}]
```

 Above all ,I think my code can fix this issue and will return nil when no valid email is provided.

BR.
