### PR TITLE
Update to oauth2

### DIFF
--- a/lib/omniauth/strategies/bitbucket.rb
+++ b/lib/omniauth/strategies/bitbucket.rb
@@ -1,15 +1,14 @@
-require 'omniauth-oauth'
+require 'omniauth-oauth2'
 
 module OmniAuth
   module Strategies
-    class Bitbucket < OmniAuth::Strategies::OAuth
+    class Bitbucket < OmniAuth::Strategies::OAuth2
       # This is where you pass the options you would pass when
       # initializing your consumer from the OAuth gem.
       option :client_options, {
         :site => 'https://bitbucket.org',
-        :request_token_path => '/api/1.0/oauth/request_token',
-        :authorize_path     => '/api/1.0/oauth/authenticate',
-        :access_token_path  => '/api/1.0/oauth/access_token'
+        :authorize_url     => 'https://bitbucket.org/site/oauth2/authorize',
+        :token_url  => 'https://bitbucket.org/site/oauth2/access_token'
       }
 
       # These are called after authentication has succeeded. If

--- a/omniauth-bitbucket.gemspec
+++ b/omniauth-bitbucket.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   s.add_dependency 'omniauth', '~> 1.1'
-  s.add_dependency 'omniauth-oauth', '~> 1.0'
+  s.add_dependency 'omniauth-oauth2', '>= 1.1.1', '< 2.0'
   s.add_dependency 'multi_json', '~> 1.7'
 
   s.add_development_dependency 'rspec', '~> 2.7'


### PR DESCRIPTION
Updated to use oAuth 2 - if you accept this, just a warn users they will need to also set their callback URL in the bitbucket config.

![image](https://cloud.githubusercontent.com/assets/13495505/11769768/c1f13f12-a23a-11e5-9a29-43d6a6eae96c.png)

However, it will solve a potential Login csrf attack 