### PR TITLE
Add a note about OAuth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is the OmniAuth strategy for authenticating to [Bitbucket](https://bitbucke
 To use it, you'll need to signup and create a new application or use your 
 existing OAuth consumer and secret keys.
 
+At a minimum, your BitBucket OAuth scopes must be set to `email,repository` for the OAuth flow to complete.
+
 ## Install
 
 Add dependency to your Gemfile:


### PR DESCRIPTION
When I tried to run through OAuth with very few scopes, the OAuth strategy did not have permission to make the required follow-up requests to the `user` and `email` endpoints. Specifically, the request on [line 31] fails with a status of `403 unauthorized`, leaving `ri == nil`, which soon throws an error.

I fixed this issue by checking the "Email" and "Repository" OAuth scopes on the BitBucket settings page.

[line 31]: https://github.com/sishen/omniauth-bitbucket/blob/master/lib/omniauth/strategies/bitbucket.rb#L31